### PR TITLE
Compile cnitool from master

### DIFF
--- a/scripts/lxd-attach-calico.sh
+++ b/scripts/lxd-attach-calico.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 name=$1
 network=$2
+interface=$3
 pid=$(sudo lxc info $name | grep 'Pid' | cut -d ':' -f 2 |  tr -d '[[:space:]]')
 
-sudo CNI_PATH=/usr/local/bin cnitool add $network /var/run/netns/$pid
+sudo mkdir -p /var/run/netns
+sudo ln -s /proc/$pid/ns/net /var/run/netns/${pid}-${interface}
+
+sudo CNI_PATH=/usr/local/bin CNI_IFNAME=$interface cnitool add $network /var/run/netns/${pid}-${interface}

--- a/scripts/lxd-create.sh
+++ b/scripts/lxd-create.sh
@@ -7,7 +7,3 @@ sudo lxc init --profile $profile ubuntu:16.04 $name
 
 # Start container
 sudo lxc start $name
-
-pid=$(sudo lxc info $name | grep 'Pid' | cut -d ':' -f 2 |  tr -d '[[:space:]]')
-sudo mkdir -p /var/run/netns
-sudo ln -s /proc/$pid/ns/net /var/run/netns/$pid

--- a/scripts/lxd-delete.sh
+++ b/scripts/lxd-delete.sh
@@ -4,5 +4,3 @@ pid=$(sudo lxc info $name | grep 'Pid' | cut -d ':' -f 2 |  tr -d '[[:space:]]')
 
 sudo lxc stop $name
 sudo lxc delete $name
-
-sudo rm -rf /var/run/netns/$pid

--- a/scripts/lxd-detach-calico.sh
+++ b/scripts/lxd-detach-calico.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 name=$1
 network=$2
+interface=$3
 pid=$(sudo lxc info $name | grep 'Pid' | cut -d ':' -f 2 |  tr -d '[[:space:]]')
 
-sudo CNI_PATH=/usr/local/bin cnitool del $network /var/run/netns/$pid
+sudo CNI_PATH=/usr/local/bin CNI_IFNAME=$interface cnitool del $network /var/run/netns/${pid}-${interface}
+sudo rm -rf /var/run/netns/${pid}-${interface}

--- a/scripts/setup_with_vanilla_code.sh
+++ b/scripts/setup_with_vanilla_code.sh
@@ -6,45 +6,78 @@ rm -rf $BUILDDIR
 mkdir -p $BUILDDIR
 
 cd $BUILDDIR
-git clone https://github.com/containernetworking/cni.git
-cd $BUILDDIR/cni
-git checkout v0.6.0
-./build.sh
-
-cd $BUILDDIR
 git clone https://github.com/projectcalico/cni-plugin.git
 cd $BUILDDIR/cni-plugin
-git checkout v3.3.1
+git checkout v3.4.0
 make build
 
-sudo cp $BUILDDIR/cni/bin/cnitool /usr/local/bin
 sudo cp $BUILDDIR/cni-plugin/bin/amd64/* /usr/local/bin
+
+export GOPATH=/home/vagrant/go/
+mkdir -p $GOPATH/src/github.com/containernetworking/
+cd $GOPATH/src/github.com/containernetworking/
+# git clone https://github.com/containernetworking/cni.git
+git clone https://github.com/quater/cni.git
+cd $GOPATH/src/github.com/containernetworking/cni
+# git checkout cnitool-for-lxc
+git checkout master
+
+go get golang.org/x/tools/cmd/cover
+go get github.com/modocache/gover
+go get github.com/mattn/goveralls
+go get -t ./...
+cd $GOPATH/src/github.com/containernetworking/cni/cnitool
+go list | xargs -n1 go build -v -o
+sudo cp github.com/containernetworking/cni/cnitool /usr/local/bin
 
 sudo mkdir -p /etc/cni/net.d
 
-sudo bash -c 'cat > /etc/calico/lxd-ipv4-pool.cfg <<EOF
+sudo bash -c 'cat > /etc/calico/lxd-ipv4-pool-frontend.cfg <<EOF
 apiVersion: projectcalico.org/v3
 kind: IPPool
 metadata:
-  name: lxd-ipv4-pool
+  name: lxd-ipv4-pool-frontend
 spec:
   cidr: 10.1.0.0/16
   ipipMode: CrossSubnet
   natOutgoing: true
 EOF'
 
-sudo bash -c 'cat > /etc/calico/lxd-ipv6-pool.cfg <<EOF
+sudo bash -c 'cat > /etc/calico/lxd-ipv6-pool-frontend.cfg <<EOF
 apiVersion: projectcalico.org/v3
 kind: IPPool
 metadata:
-  name: lxd-ipv6-pool
+  name: lxd-ipv6-pool-frontend
 spec:
   cidr: 2001:db8:1234:1::/64
   ipipMode: Never
 EOF'
 
-sudo calicoctl create -f /etc/calico/lxd-ipv4-pool.cfg
-sudo calicoctl create -f /etc/calico/lxd-ipv6-pool.cfg
+sudo bash -c 'cat > /etc/calico/lxd-ipv4-pool-backend.cfg <<EOF
+apiVersion: projectcalico.org/v3
+kind: IPPool
+metadata:
+  name: lxd-ipv4-pool-backend
+spec:
+  cidr: 10.3.0.0/16
+  ipipMode: CrossSubnet
+  natOutgoing: true
+EOF'
+
+sudo bash -c 'cat > /etc/calico/lxd-ipv6-pool-backend.cfg <<EOF
+apiVersion: projectcalico.org/v3
+kind: IPPool
+metadata:
+  name: lxd-ipv6-pool-backend
+spec:
+  cidr: 2001:db8:1222:1::/64
+  ipipMode: Never
+EOF'
+
+sudo calicoctl create -f /etc/calico/lxd-ipv4-pool-frontend.cfg
+sudo calicoctl create -f /etc/calico/lxd-ipv6-pool-frontend.cfg
+sudo calicoctl create -f /etc/calico/lxd-ipv4-pool-backend.cfg
+sudo calicoctl create -f /etc/calico/lxd-ipv6-pool-backend.cfg
 
 sudo -E bash -c 'cat > /etc/cni/net.d/10-frontend-calico.conf <<EOF
 {
@@ -57,8 +90,25 @@ sudo -E bash -c 'cat > /etc/cni/net.d/10-frontend-calico.conf <<EOF
         "type": "calico-ipam",
         "assign_ipv4": "true",
         "assign_ipv6": "true",
-        "ipv4_pools": ["lxd-ipv4-pool"],
-        "ipv6_pools": ["lxd-ipv6-pool"]
+        "ipv4_pools": ["lxd-ipv4-pool-frontend"],
+        "ipv6_pools": ["lxd-ipv6-pool-frontend"]
+    }
+}
+EOF'
+
+sudo -E bash -c 'cat > /etc/cni/net.d/10-backend-calico.conf <<EOF
+{
+    "name": "backend",
+    "cniVersion": "0.3.1",
+    "type": "calico",
+    "log_level": "DEBUG",
+    "etcd_endpoints": "http://127.0.0.1:2379",
+    "ipam": {
+        "type": "calico-ipam",
+        "assign_ipv4": "true",
+        "assign_ipv6": "true",
+        "ipv4_pools": ["lxd-ipv4-pool-backend"],
+        "ipv6_pools": ["lxd-ipv6-pool-backend"]
     }
 }
 EOF'


### PR DESCRIPTION
With the current containernetworking/cni master branch, the cnitool generates a container Id by generating a hash from the namespace path. This allows to successfully attach one network interface per lxc/lxd container.