### PR TITLE
Pinned CNI repo to a commit

### DIFF
--- a/scripts/setup_with_vanilla_code.sh
+++ b/scripts/setup_with_vanilla_code.sh
@@ -14,13 +14,12 @@ make build
 sudo cp $BUILDDIR/cni-plugin/bin/amd64/* /usr/local/bin
 
 export GOPATH=/home/vagrant/go/
+rm -rf $GOPATH/src/github.com/containernetworking/
 mkdir -p $GOPATH/src/github.com/containernetworking/
 cd $GOPATH/src/github.com/containernetworking/
-# git clone https://github.com/containernetworking/cni.git
-git clone https://github.com/quater/cni.git
+git clone https://github.com/containernetworking/cni.git
 cd $GOPATH/src/github.com/containernetworking/cni
-# git checkout cnitool-for-lxc
-git checkout master
+git checkout 42e857f0a2bfe4048a592c1bc634dfdfdb68c42f
 
 go get golang.org/x/tools/cmd/cover
 go get github.com/modocache/gover


### PR DESCRIPTION
When building the cnitool, the git repository is now checked out at a particular commit rather than on the master branch head. This ensures that this code continues to work regardless of any future changes that might be introduced.